### PR TITLE
angoose-client -> angoose.client

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Restart node.js
 
   
 
-#### 4. In your main angular app, add `angoose-client` to your app module dependencies. For example:
+#### 4. In your main angular app, add `angoose.client` to your app module dependencies. For example:
 
     var myapp = angular.module('myapp', ['ngRoute',   'angoose.client']);
 


### PR DESCRIPTION
Figured it'd be best to match these. I spent some time figuring out why I was getting a module not found error in my angular app